### PR TITLE
URLが長くなり過ぎるので、hashを文字列に変換後のものから先頭の10文字を取得するように

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,7 +30,7 @@ func initDB() {
 
 func generateHash(url string) string {
 	hash := sha256.Sum256([]byte(url))
-	return hex.EncodeToString(hash[:10])
+	return hex.EncodeToString(hash[:])[:10]
 }
 
 type RequestData struct {


### PR DESCRIPTION
表題の通り