### PR TITLE
#26 データベースへのアクセスロジックを抽象化

### DIFF
--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -1,13 +1,24 @@
 package config
 
 import (
+	"log"
 	"os"
 )
 
-var AppConfig struct {
+type AppConfig struct {
 	BaseUrl string
 }
 
+var AppConf AppConfig
+
 func LoadAppConfig() {
-	AppConfig.BaseUrl = os.Getenv("BASE_URL")
+	conf := AppConfig{
+		BaseUrl: os.Getenv("BASE_URL"),
+	}
+
+	if conf.BaseUrl == "" {
+		log.Fatal("Missing required environment variable BASE_URL")
+	}
+
+	AppConf = conf
 }

--- a/internal/config/database.go
+++ b/internal/config/database.go
@@ -1,40 +1,32 @@
 package config
 
 import (
-	"fmt"
 	"log"
 	"os"
 
-	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 )
 
-var DBConfig struct {
+type DBConfig struct {
 	User string
 	Host string
 	Name string
 	Pass string
-	DB   *sqlx.DB
 }
+
+var PostgresConf DBConfig
 
 func LoadDBConfig() {
-	DBConfig.User = os.Getenv("DB_USER")
-	DBConfig.Host = os.Getenv("DB_HOST")
-	DBConfig.Name = os.Getenv("DB_NAME")
-	DBConfig.Pass = os.Getenv("DB_PASS")
-
-	if DBConfig.User == "" || DBConfig.Host == "" || DBConfig.Name == "" || DBConfig.Pass == "" {
-		log.Fatal("Missing required environment variables")
+	config := DBConfig{
+		User: os.Getenv("DB_USER"),
+		Host: os.Getenv("DB_HOST"),
+		Name: os.Getenv("DB_NAME"),
+		Pass: os.Getenv("DB_PASS"),
 	}
 
-	InitDB()
-}
-
-func InitDB() {
-	dsn := fmt.Sprintf("user=%s password=%s host=%s dbname=%s sslmode=%s", DBConfig.User, DBConfig.Pass, DBConfig.Host, DBConfig.Name, "disable")
-	var err error
-	DBConfig.DB, err = sqlx.Open("postgres", dsn)
-	if err != nil {
-		log.Fatal("Failed to connect to DB: ", err)
+	if config.User == "" || config.Host == "" || config.Name == "" || config.Pass == "" {
+		log.Fatal("Missing required db environment variables")
 	}
+
+	PostgresConf = config
 }

--- a/internal/handler/redirect.go
+++ b/internal/handler/redirect.go
@@ -14,12 +14,15 @@ func RedirectURL(w http.ResponseWriter, r *http.Request) {
 	hash := r.URL.Path[1:]
 	var originalURL string
 
-	ada, err := adaptor.NewPostgresAdapter()
+	dbAdaptor := adaptor.NewPostgresAdaptor()
+	db, err := dbAdaptor()
 	if err != nil {
-		log.Fatal(err)
+		log.Println("Failed to connect to database: ", err)
+		utils.RespondWithError(w, http.StatusInternalServerError, "Internal Server Error")
+		return
 	}
 
-	err = ada.Get(&originalURL, "SELECT original_url FROM short_url_mappings WHERE hash = $1", hash)
+	err = db.Get(&originalURL, "SELECT original_url FROM short_url_mappings WHERE hash = $1", hash)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			http.Error(w, "Not Found", http.StatusNotFound)

--- a/internal/handler/redirect.go
+++ b/internal/handler/redirect.go
@@ -6,14 +6,20 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/Kiyo510/url-shorter/internal/config"
+	"github.com/Kiyo510/url-shorter/internal/infrastructure/adaptor"
 	"github.com/Kiyo510/url-shorter/internal/utils"
 )
 
 func RedirectURL(w http.ResponseWriter, r *http.Request) {
 	hash := r.URL.Path[1:]
 	var originalURL string
-	err := config.DBConfig.DB.Get(&originalURL, "SELECT original_url FROM short_url_mappings WHERE hash = $1", hash)
+
+	ada, err := adaptor.NewPostgresAdapter()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = ada.Get(&originalURL, "SELECT original_url FROM short_url_mappings WHERE hash = $1", hash)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			http.Error(w, "Not Found", http.StatusNotFound)
@@ -23,5 +29,6 @@ func RedirectURL(w http.ResponseWriter, r *http.Request) {
 		utils.RespondWithError(w, http.StatusInternalServerError, "Internal Server Error")
 		return
 	}
+
 	http.Redirect(w, r, originalURL, http.StatusFound)
 }

--- a/internal/infrastructure/adaptor/postgres.go
+++ b/internal/infrastructure/adaptor/postgres.go
@@ -1,0 +1,39 @@
+package adaptor
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/Kiyo510/url-shorter/internal/config"
+	"github.com/jmoiron/sqlx"
+)
+
+// TODO: contextを受け取るようにする
+type DBAdapter interface {
+	Get(dest interface{}, query string, args ...interface{}) error
+	Exec(query string, args ...interface{}) (sql.Result, error)
+}
+
+type postgresAdapter struct {
+	db *sqlx.DB
+}
+
+func (p *postgresAdapter) Exec(query string, args ...interface{}) (sql.Result, error) {
+	return p.db.Exec(query, args...)
+}
+
+func (p *postgresAdapter) Get(dest interface{}, query string, args ...interface{}) error {
+	return p.db.Get(dest, query, args...)
+}
+
+// TODO: contextを受け取るために、関数型を返すようにしても良いかも
+func NewPostgresAdapter() (DBAdapter, error) {
+	conf := config.PostgresConf
+	dsn := fmt.Sprintf("user=%s password=%s host=%s dbname=%s sslmode=%s", conf.User, conf.Pass, conf.Host, conf.Name, "disable")
+	db, err := sqlx.Open("postgres", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("sqlx connect failed: %w", err)
+	}
+
+	return &postgresAdapter{db: db}, nil
+}

--- a/internal/infrastructure/adaptor/postgres.go
+++ b/internal/infrastructure/adaptor/postgres.go
@@ -1,39 +1,29 @@
 package adaptor
 
 import (
-	"database/sql"
 	"fmt"
+	"sync"
 
 	"github.com/Kiyo510/url-shorter/internal/config"
 	"github.com/jmoiron/sqlx"
 )
 
-// TODO: contextを受け取るようにする
-type DBAdapter interface {
-	Get(dest interface{}, query string, args ...interface{}) error
-	Exec(query string, args ...interface{}) (sql.Result, error)
-}
-
-type postgresAdapter struct {
-	db *sqlx.DB
-}
-
-func (p *postgresAdapter) Exec(query string, args ...interface{}) (sql.Result, error) {
-	return p.db.Exec(query, args...)
-}
-
-func (p *postgresAdapter) Get(dest interface{}, query string, args ...interface{}) error {
-	return p.db.Get(dest, query, args...)
-}
-
-// TODO: contextを受け取るために、関数型を返すようにしても良いかも
-func NewPostgresAdapter() (DBAdapter, error) {
-	conf := config.PostgresConf
-	dsn := fmt.Sprintf("user=%s password=%s host=%s dbname=%s sslmode=%s", conf.User, conf.Pass, conf.Host, conf.Name, "disable")
-	db, err := sqlx.Open("postgres", dsn)
-	if err != nil {
-		return nil, fmt.Errorf("sqlx connect failed: %w", err)
+func NewPostgresAdaptor() DBConn {
+	var dba DBAdaptor
+	var mtx sync.Mutex
+	return func() (DBAdaptor, error) {
+		mtx.Lock()
+		defer mtx.Unlock()
+		if dba != nil {
+			return dba, nil
+		}
+		conf := config.PostgresConf
+		dsn := fmt.Sprintf("user=%s password=%s host=%s dbname=%s sslmode=%s", conf.User, conf.Pass, conf.Host, conf.Name, "disable")
+		db, err := sqlx.Open("postgres", dsn)
+		if err != nil {
+			return nil, fmt.Errorf("sqlx connect failed: %w", err)
+		}
+		dba = &sqlxConn{conn: db}
+		return dba, nil
 	}
-
-	return &postgresAdapter{db: db}, nil
 }

--- a/internal/infrastructure/adaptor/sqlx_conn.go
+++ b/internal/infrastructure/adaptor/sqlx_conn.go
@@ -1,0 +1,27 @@
+package adaptor
+
+import (
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+)
+
+type DBConn func() (DBAdaptor, error)
+
+// TODO: contextを受け取るようにする
+type DBAdaptor interface {
+	Get(dest interface{}, query string, args ...interface{}) error
+	Exec(query string, args ...interface{}) (sql.Result, error)
+}
+
+type sqlxConn struct {
+	conn *sqlx.DB
+}
+
+func (s *sqlxConn) Get(dest interface{}, query string, args ...interface{}) error {
+	return s.conn.Get(dest, query, args...)
+}
+
+func (s *sqlxConn) Exec(query string, args ...interface{}) (sql.Result, error) {
+	return s.conn.Exec(query, args...)
+}


### PR DESCRIPTION
# やったこと
インフラ層にPostgresへ接続するためのアダプターを用意し、データベースへのアクセスロジックを抽象化

- こうすることで、下記メリットがあります
  - DBへのアクセスロジックを一箇所で管理できる
  - インターフェースで制約をもたせることでコードのバラつきを無くすことできる

最終的には引数でcontextを渡すようにして、DBへの接続タイムアウトなどを制御するなどの拡張性を持たせるようにしたい。(これはGoではよくやります)

Close #26  